### PR TITLE
create smartlib session on each media loading

### DIFF
--- a/broadpeakplugin/src/main/java/com/kaltura/playkit/plugins/broadpeak/BroadpeakPlugin.java
+++ b/broadpeakplugin/src/main/java/com/kaltura/playkit/plugins/broadpeak/BroadpeakPlugin.java
@@ -90,7 +90,10 @@ public class BroadpeakPlugin extends PKPlugin implements PKMediaEntryInterceptor
         if (session != null)
             session.stopStreamingSession();
 
-        player = null;
+        if (player != null) {
+            player.destroy();
+            player = null;
+        }
 
         // Release SmartLib
         SmartLib.getInstance().release();

--- a/broadpeakplugin/src/main/java/com/kaltura/playkit/plugins/broadpeak/BroadpeakPlugin.java
+++ b/broadpeakplugin/src/main/java/com/kaltura/playkit/plugins/broadpeak/BroadpeakPlugin.java
@@ -87,8 +87,10 @@ public class BroadpeakPlugin extends PKPlugin implements PKMediaEntryInterceptor
     @Override
     protected void onDestroy() {
         // Stop the session
-        if (session != null)
+        if (session != null) {
             session.stopStreamingSession();
+            session = null;
+        }
 
         if (player != null) {
             player.destroy();

--- a/broadpeakplugin/src/main/java/com/kaltura/playkit/plugins/broadpeak/BroadpeakPlugin.java
+++ b/broadpeakplugin/src/main/java/com/kaltura/playkit/plugins/broadpeak/BroadpeakPlugin.java
@@ -25,6 +25,7 @@ public class BroadpeakPlugin extends PKPlugin implements PKMediaEntryInterceptor
     private final String SMARTLIB_PRE_STARTUP_TIME_KEY = "pre_startup_time";
     private MessageBus messageBus;
     private StreamingSession session;
+    private Player player;
     private long requestStartTime;
 
     public static final Factory factory = new Factory() {
@@ -61,11 +62,8 @@ public class BroadpeakPlugin extends PKPlugin implements PKMediaEntryInterceptor
                 bpConfig.getNanoCDNHost(),
                 bpConfig.getBroadpeakDomainNames()
         );
-        session = SmartLib.getInstance().createStreamingSession();
-
+        this.player = player;
         this.messageBus = messageBus;
-
-        session.attachPlayer(player);
 
         requestStartTime = System.currentTimeMillis();
     }
@@ -89,7 +87,10 @@ public class BroadpeakPlugin extends PKPlugin implements PKMediaEntryInterceptor
     @Override
     protected void onDestroy() {
         // Stop the session
-        session.stopStreamingSession();
+        if (session != null)
+            session.stopStreamingSession();
+
+        player = null;
 
         // Release SmartLib
         SmartLib.getInstance().release();
@@ -108,6 +109,8 @@ public class BroadpeakPlugin extends PKPlugin implements PKMediaEntryInterceptor
                 !mediaEntry.getSources().isEmpty() && mediaEntry.getSources().get(0) != null) {
             PKMediaSource source = mediaEntry.getSources().get(0);
             // Start the session and get the final stream URL
+            session = SmartLib.getInstance().createStreamingSession();
+            session.attachPlayer(player);
             StreamingSessionResult result = session.getURL(source.getUrl());
             if (result != null && !result.isError()) {
                 // Replace the URL


### PR DESCRIPTION
Create smartlib session on each media loading, because session is available only for one request execution. These changes cover case of change media without player recreation, e.g. playing next episode for series, program "zapping", etc.