### PR TITLE
feat(KUX-2242): Broadpeak keep-alive frequency configurable

### DIFF
--- a/broadpeakplugin/src/main/java/com/kaltura/playkit/plugins/broadpeak/BroadpeakPlugin.java
+++ b/broadpeakplugin/src/main/java/com/kaltura/playkit/plugins/broadpeak/BroadpeakPlugin.java
@@ -344,6 +344,10 @@ public class BroadpeakPlugin extends PKPlugin implements PKMediaEntryInterceptor
                         session.setOption(entry.getKey(), (boolean) entry.getValue());
                     } else if (entry.getValue() instanceof String) {
                         session.setOption(entry.getKey(), entry.getValue().toString());
+                    } else if (entry.getValue() instanceof  Float) {
+                        session.setOption(entry.getKey(), ((Float) entry.getValue()).intValue());
+                    } else if (entry.getValue() instanceof  Double) {
+                        session.setOption(entry.getKey(), ((Double) entry.getValue()).intValue());
                     }
                 }
             }


### PR DESCRIPTION
### What's done
- KUX-2242
- broadpeak configuration sent to plugin is parsed from json into class and value is converted into Double object
- added implementation to set value for option if value is instance of Double or Float